### PR TITLE
autogen.sh: don't run aclocal

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -22,7 +22,8 @@ if [ "$#" = 0 -a "x$NOCONFIGURE" = "x" ]; then
     echo "" >&2
 fi
 
-aclocal --install || exit 1
+mkdir -p m4
+
 intltoolize --force --copy --automake || exit 1
 autoreconf --verbose --force --install || exit 1
 


### PR DESCRIPTION
autoreconf takes care of running aclocal and other commands in the right order.